### PR TITLE
Create Obrato SAS service portfolio website

### DIFF
--- a/assets/cuadrillas-jardineria.svg
+++ b/assets/cuadrillas-jardineria.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1b98f5"/>
+      <stop offset="100%" stop-color="#0e4d92"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="24" fill="url(#bg)"/>
+  <g fill="none" stroke="#fefefe" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="48" cy="52" r="18"/>
+    <circle cx="112" cy="52" r="18"/>
+    <path d="M24 128l12-38c6-20 18-20 24 0l8 28 8-28c6-20 18-20 24 0l12 38"/>
+    <path d="M40 128h80"/>
+  </g>
+</svg>

--- a/assets/jardineros.svg
+++ b/assets/jardineros.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#6ab04c"/>
+      <stop offset="100%" stop-color="#0a6c5c"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="24" fill="url(#bg)"/>
+  <g fill="none" stroke="#fefefe" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M32 122c20-46 44-60 48-60s28 14 48 60"/>
+    <path d="M80 62s8-30 28-36c0 0-8 28 12 34 0 0-22 6-40 38"/>
+    <circle cx="80" cy="118" r="14"/>
+  </g>
+</svg>

--- a/assets/locativas.svg
+++ b/assets/locativas.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#34495e"/>
+      <stop offset="100%" stop-color="#2c3e50"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="24" fill="url(#bg)"/>
+  <g fill="none" stroke="#fefefe" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M36 126V70l44-26 44 26v56"/>
+    <path d="M60 126v-32h40v32"/>
+    <path d="M80 54v18"/>
+    <path d="M96 92l18 18"/>
+    <path d="M64 92l-18 18"/>
+  </g>
+</svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 220">
+  <rect width="480" height="220" fill="#f5f7f9"/>
+  <g stroke="#0f2a37" stroke-width="6" fill="none" stroke-linecap="round">
+    <path d="M60 40v140"/>
+    <path d="M90 20v180"/>
+    <path d="M30 80h150"/>
+    <path d="M30 140h150"/>
+  </g>
+  <g font-family="'Playfair Display', 'Times New Roman', serif" font-weight="600" fill="#0f2a37" font-size="96">
+    <text x="140" y="126" letter-spacing="12">OBRATO</text>
+  </g>
+  <text x="402" y="152" font-family="'Montserrat', sans-serif" font-size="28" fill="#0f2a37">S.A.S</text>
+  <path d="M226 96c0-26 18-46 42-46s42 20 42 46-18 46-42 46-42-20-42-46z" fill="#0d4650" opacity="0.18"/>
+  <path d="M242 94c0-13.25 9.17-24 20.5-24s20.5 10.75 20.5 24-9.17 24-20.5 24S242 107.25 242 94z" fill="#0f8c8c" opacity="0.75"/>
+  <path d="M262 70c6 10 6 26 0 36 12-4 20-12 24-20-6-8-12-12-24-16z" fill="#f5f7f9"/>
+</svg>

--- a/assets/ornamentacion.svg
+++ b/assets/ornamentacion.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ffe066"/>
+      <stop offset="100%" stop-color="#ff6b6b"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="24" fill="url(#bg)"/>
+  <g fill="none" stroke="#fefefe" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M80 34c18 18 18 42 0 60-18-18-18-42 0-60z"/>
+    <path d="M46 84c22 0 34 10 34 24 0 14-12 18-34 18"/>
+    <path d="M114 84c-22 0-34 10-34 24 0 14 12 18 34 18"/>
+    <circle cx="80" cy="120" r="10"/>
+  </g>
+</svg>

--- a/assets/personal-servicios.svg
+++ b/assets/personal-servicios.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f2994a"/>
+      <stop offset="100%" stop-color="#e056fd"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="24" fill="url(#bg)"/>
+  <g fill="none" stroke="#fefefe" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="80" cy="50" r="18"/>
+    <path d="M44 128l10-32c6-20 36-20 42 0l10 32"/>
+    <path d="M60 90h40"/>
+    <path d="M80 72v18"/>
+  </g>
+</svg>

--- a/assets/toderos.svg
+++ b/assets/toderos.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f8c8c"/>
+      <stop offset="100%" stop-color="#1f4068"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="24" fill="url(#bg)"/>
+  <g stroke="#fefefe" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <circle cx="80" cy="48" r="20" fill="none"/>
+    <path d="M40 128l12-46c4-14 20-14 24 0l8 26 12-38c4-12 22-12 26 0l10 30"/>
+    <path d="M40 128h80"/>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,899 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Obrato S.A.S | Portafolio de servicios</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600;700&family=Playfair+Display:wght@500;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --primary: #0f8c8c;
+      --secondary: #0f2a37;
+      --accent: #f2994a;
+      --bg: #f4f7f8;
+      --card-bg: rgba(255, 255, 255, 0.75);
+      --text: #1f2d3d;
+      --muted: #6b7b8c;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      scroll-behavior: smooth;
+      overflow-x: hidden;
+    }
+
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      background: rgba(244, 247, 248, 0.85);
+      backdrop-filter: blur(18px);
+      border-bottom: 1px solid rgba(15, 42, 55, 0.08);
+    }
+
+    .nav-bar {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1.5rem;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .brand img {
+      width: 72px;
+      height: auto;
+      display: block;
+    }
+
+    .brand span {
+      font-family: 'Playfair Display', serif;
+      font-size: clamp(1.4rem, 2vw, 1.8rem);
+      letter-spacing: 0.12em;
+      color: var(--secondary);
+    }
+
+    nav ul {
+      list-style: none;
+      display: flex;
+      gap: 1.25rem;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    nav a {
+      color: var(--muted);
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.95rem;
+      position: relative;
+      transition: color 0.3s ease;
+    }
+
+    nav a::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      bottom: -0.3rem;
+      width: 100%;
+      height: 2px;
+      transform: scaleX(0);
+      transform-origin: left;
+      background: var(--primary);
+      transition: transform 0.3s ease;
+    }
+
+    nav a:hover,
+    nav a:focus {
+      color: var(--secondary);
+    }
+
+    nav a:hover::after,
+    nav a:focus::after,
+    nav a.active::after {
+      transform: scaleX(1);
+    }
+
+    .hero {
+      position: relative;
+      padding: 8rem 1.5rem 6rem;
+      background: linear-gradient(135deg, rgba(15, 140, 140, 0.12) 0%, rgba(15, 42, 55, 0.24) 70%),
+        radial-gradient(circle at 20% -10%, rgba(242, 153, 74, 0.35) 0%, transparent 55%),
+        var(--bg);
+      overflow: hidden;
+    }
+
+    .hero::before,
+    .hero::after {
+      content: "";
+      position: absolute;
+      width: 420px;
+      height: 420px;
+      background: radial-gradient(circle, rgba(15, 140, 140, 0.18), transparent 65%);
+      border-radius: 50%;
+      z-index: 0;
+      transform: translate3d(0,0,0);
+      animation: float 14s ease-in-out infinite;
+    }
+
+    .hero::before {
+      top: -160px;
+      right: -120px;
+    }
+
+    .hero::after {
+      bottom: -220px;
+      left: -120px;
+      animation-delay: -6s;
+    }
+
+    @keyframes float {
+      0%, 100% { transform: translateY(0) scale(1); }
+      50% { transform: translateY(-26px) scale(1.05); }
+    }
+
+    .hero-content {
+      max-width: 1100px;
+      margin: 0 auto;
+      position: relative;
+      z-index: 1;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 2.5rem;
+      align-items: center;
+    }
+
+    .hero-copy h1 {
+      font-family: 'Playfair Display', serif;
+      font-size: clamp(2.5rem, 6vw, 3.75rem);
+      color: var(--secondary);
+      line-height: 1.15;
+      margin-bottom: 1.5rem;
+    }
+
+    .hero-copy p {
+      max-width: 480px;
+      color: var(--muted);
+      font-size: 1.05rem;
+      margin-bottom: 2rem;
+    }
+
+    .cta-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    .btn {
+      padding: 0.85rem 1.8rem;
+      border-radius: 999px;
+      border: 2px solid transparent;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      cursor: pointer;
+      transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+    }
+
+    .btn-primary {
+      background: var(--primary);
+      color: #fff;
+      box-shadow: 0 18px 28px rgba(15, 140, 140, 0.25);
+    }
+
+    .btn-outline {
+      background: transparent;
+      border-color: rgba(15, 42, 55, 0.2);
+      color: var(--secondary);
+    }
+
+    .btn:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 22px 32px rgba(15, 140, 140, 0.32);
+    }
+
+    .hero-panel {
+      background: rgba(255, 255, 255, 0.72);
+      backdrop-filter: blur(22px);
+      border-radius: 32px;
+      padding: 2.25rem;
+      box-shadow: 0 30px 80px rgba(15, 42, 55, 0.18);
+      display: grid;
+      gap: 1.25rem;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero-panel::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at top right, rgba(15, 140, 140, 0.1), transparent 55%);
+      pointer-events: none;
+    }
+
+    .hero-panel h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.3em;
+      color: var(--primary);
+    }
+
+    .hero-panel p {
+      color: var(--secondary);
+      font-size: 1.1rem;
+      font-weight: 600;
+    }
+
+    .hero-panel ul {
+      list-style: none;
+      display: grid;
+      gap: 0.75rem;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    section {
+      padding: 5rem 1.5rem;
+      position: relative;
+    }
+
+    .section-inner {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: grid;
+      gap: 2.75rem;
+    }
+
+    .section-heading {
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+      max-width: 720px;
+    }
+
+    .section-heading span {
+      font-size: 0.85rem;
+      letter-spacing: 0.28em;
+      text-transform: uppercase;
+      color: var(--primary);
+      font-weight: 700;
+    }
+
+    .section-heading h2 {
+      font-size: clamp(2rem, 4vw, 2.6rem);
+      font-family: 'Playfair Display', serif;
+      color: var(--secondary);
+    }
+
+    .section-heading p {
+      color: var(--muted);
+    }
+
+    .grid-2 {
+      display: grid;
+      gap: 2rem;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    .card {
+      background: var(--card-bg);
+      border-radius: 24px;
+      padding: 2.2rem;
+      box-shadow: 0 30px 60px rgba(15, 42, 55, 0.12);
+      border: 1px solid rgba(15, 42, 55, 0.06);
+      position: relative;
+      overflow: hidden;
+      transition: transform 0.4s ease, box-shadow 0.4s ease;
+    }
+
+    .card::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(255,255,255,0.0) 30%, rgba(15, 140, 140, 0.12));
+      opacity: 0;
+      transition: opacity 0.4s ease;
+    }
+
+    .card:hover {
+      transform: translateY(-10px);
+      box-shadow: 0 36px 70px rgba(15, 42, 55, 0.16);
+    }
+
+    .card:hover::after {
+      opacity: 1;
+    }
+
+    .card h3 {
+      font-size: 1.4rem;
+      margin-bottom: 0.75rem;
+      color: var(--secondary);
+    }
+
+    .card p {
+      color: var(--muted);
+    }
+
+    .card img {
+      width: 96px;
+      height: 96px;
+      object-fit: contain;
+      margin-bottom: 1.4rem;
+    }
+
+    .services-grid {
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .services-card {
+      text-align: left;
+    }
+
+    .contact-form {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .contact-form label {
+      font-weight: 600;
+      color: var(--secondary);
+    }
+
+    .contact-form input,
+    .contact-form select,
+    .contact-form textarea {
+      width: 100%;
+      padding: 0.85rem 1rem;
+      border-radius: 14px;
+      border: 1px solid rgba(15, 42, 55, 0.12);
+      background: rgba(255, 255, 255, 0.9);
+      font-size: 0.95rem;
+      font-family: inherit;
+      color: var(--text);
+      transition: border 0.3s ease, box-shadow 0.3s ease;
+      resize: vertical;
+    }
+
+    .contact-form input:focus,
+    .contact-form select:focus,
+    .contact-form textarea:focus {
+      outline: none;
+      border-color: rgba(15, 140, 140, 0.5);
+      box-shadow: 0 0 0 4px rgba(15, 140, 140, 0.16);
+    }
+
+    .contact-form textarea {
+      min-height: 140px;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.35rem 0.9rem;
+      border-radius: 999px;
+      background: rgba(15, 140, 140, 0.12);
+      color: var(--primary);
+      font-weight: 600;
+      font-size: 0.85rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .list-columns {
+      columns: 2;
+      gap: 2rem;
+      list-style: none;
+      padding: 0;
+    }
+
+    .list-columns li {
+      margin-bottom: 0.75rem;
+      position: relative;
+      padding-left: 1.6rem;
+      color: var(--muted);
+    }
+
+    .list-columns li::before {
+      content: "";
+      width: 0.65rem;
+      height: 0.65rem;
+      border-radius: 50%;
+      background: var(--primary);
+      position: absolute;
+      left: 0;
+      top: 0.5rem;
+      box-shadow: 0 0 0 6px rgba(15, 140, 140, 0.12);
+    }
+
+    .dotacion-wrapper {
+      display: grid;
+      gap: 2rem;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      align-items: start;
+    }
+
+    .dotacion-card {
+      border-left: 4px solid var(--primary);
+      padding: 1.8rem 2rem;
+      border-radius: 20px;
+      background: var(--card-bg);
+      box-shadow: 0 18px 40px rgba(15, 42, 55, 0.1);
+    }
+
+    .dotacion-card h3 {
+      font-size: 1.25rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .timeline {
+      display: grid;
+      gap: 1.5rem;
+      position: relative;
+      padding-left: 1.5rem;
+    }
+
+    .timeline::before {
+      content: "";
+      position: absolute;
+      left: 0.25rem;
+      top: 0.5rem;
+      bottom: 0.5rem;
+      width: 2px;
+      background: linear-gradient(var(--primary), rgba(15,140,140,0));
+    }
+
+    .timeline li {
+      list-style: none;
+      background: rgba(255,255,255,0.6);
+      border: 1px solid rgba(15, 42, 55, 0.08);
+      border-radius: 16px;
+      padding: 1.4rem;
+      position: relative;
+      box-shadow: 0 18px 40px rgba(15, 42, 55, 0.08);
+    }
+
+    .timeline li::before {
+      content: "";
+      position: absolute;
+      left: -1.05rem;
+      top: 1.6rem;
+      width: 0.85rem;
+      height: 0.85rem;
+      border-radius: 50%;
+      background: #fff;
+      border: 2px solid var(--primary);
+      box-shadow: 0 0 0 8px rgba(15, 140, 140, 0.12);
+    }
+
+    footer {
+      background: var(--secondary);
+      color: rgba(255, 255, 255, 0.86);
+      padding: 3rem 1.5rem;
+    }
+
+    footer .footer-inner {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: grid;
+      gap: 2rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    footer small {
+      display: block;
+      margin-top: 1.5rem;
+      text-align: center;
+      color: rgba(255, 255, 255, 0.6);
+    }
+
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .metric {
+      background: rgba(255,255,255,0.18);
+      padding: 1.2rem;
+      border-radius: 18px;
+      text-align: center;
+      color: #fff;
+    }
+
+    .metric strong {
+      display: block;
+      font-size: 2rem;
+      font-family: 'Playfair Display', serif;
+    }
+
+    .animate-on-scroll {
+      opacity: 0;
+      transform: translateY(28px);
+      transition: opacity 0.8s ease, transform 0.8s ease;
+    }
+
+    .animate-on-scroll.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    @media (max-width: 720px) {
+      nav ul {
+        width: 100%;
+        justify-content: center;
+      }
+
+      .hero {
+        padding-top: 6.5rem;
+      }
+
+      .hero-panel {
+        order: -1;
+      }
+
+      .list-columns {
+        columns: 1;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="nav-bar">
+      <a href="#inicio" class="brand">
+        <img src="assets/logo.svg" alt="Logotipo Obrato S.A.S" />
+        <span>Obrato S.A.S</span>
+      </a>
+      <nav>
+        <ul>
+          <li><a href="#inicio" class="active">Inicio</a></li>
+          <li><a href="#empresa">Empresa</a></li>
+          <li><a href="#servicios">Servicios</a></li>
+          <li><a href="#dotacion">Dotación</a></li>
+          <li><a href="#contacto">Contacto</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero" id="inicio">
+      <div class="hero-content">
+        <div class="hero-copy animate-on-scroll">
+          <h1>Servicios integrales con calidad y respaldo.</h1>
+          <p>
+            Somos aliados estratégicos para la gestión de espacios corporativos y residenciales. 
+            Nuestro equipo especializado garantiza soluciones oportunas, eficientes y sostenibles.
+          </p>
+          <div class="cta-group">
+            <a class="btn btn-primary" href="#servicios">Explorar servicios</a>
+            <a class="btn btn-outline" href="#contacto">Solicitar propuesta</a>
+          </div>
+        </div>
+        <aside class="hero-panel animate-on-scroll">
+          <h2>Portafolio destacado</h2>
+          <p>Obrato S.A.S cuida los detalles para que tus instalaciones transmitan confianza.</p>
+          <ul>
+            <li>+10 años de experiencia en facility services.</li>
+            <li>Equipo certificado en seguridad industrial y SST.</li>
+            <li>Intervenciones a la medida de tus necesidades.</li>
+          </ul>
+          <div class="metrics">
+            <div class="metric">
+              <strong>98%</strong>
+              <span>Satisfacción</span>
+            </div>
+            <div class="metric">
+              <strong>24/7</strong>
+              <span>Disponibilidad</span>
+            </div>
+            <div class="metric">
+              <strong>120+</strong>
+              <span>Operarios</span>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </section>
+
+    <section id="empresa">
+      <div class="section-inner">
+        <div class="section-heading animate-on-scroll">
+          <span>Nuestra esencia</span>
+          <h2>Construimos confianza con talento humano y procesos sostenibles.</h2>
+          <p>
+            Obrato S.A.S es una compañía colombiana dedicada a la prestación de servicios integrales de mantenimiento, jardinería y apoyo operativo. 
+            Creamos experiencias memorables en cada espacio que administramos, generando valor a través de la innovación y la mejora continua.
+          </p>
+        </div>
+        <div class="grid-2">
+          <article class="card animate-on-scroll">
+            <span class="badge">Misión</span>
+            <h3>Garantizar bienestar y productividad</h3>
+            <p>
+              Prestamos servicios oportunos y confiables en mantenimiento locativo, jardinería y apoyo operacional para organizaciones públicas y privadas. 
+              Promovemos la seguridad, la sostenibilidad y la satisfacción de nuestros clientes mediante equipos competentes y tecnología aplicada.
+            </p>
+          </article>
+          <article class="card animate-on-scroll">
+            <span class="badge">Visión</span>
+            <h3>Ser referentes en soluciones integrales</h3>
+            <p>
+              Para 2028 consolidaremos una red nacional de servicios con estándares de clase mundial, 
+              posicionándonos como aliado estratégico por nuestra capacidad de respuesta, innovación y cultura de servicio.
+            </p>
+          </article>
+          <article class="card animate-on-scroll">
+            <span class="badge">Objetivos</span>
+            <ul class="list-columns">
+              <li>Diseñar planes operativos personalizados para cada cliente.</li>
+              <li>Impulsar la capacitación continua del talento humano.</li>
+              <li>Implementar prácticas ambientales responsables en cada servicio.</li>
+              <li>Optimizar recursos mediante indicadores y analítica en tiempo real.</li>
+              <li>Mantener una tasa de satisfacción superior al 95%.</li>
+              <li>Fortalecer alianzas estratégicas con proveedores certificados.</li>
+            </ul>
+          </article>
+          <article class="card animate-on-scroll">
+            <span class="badge">Sobre la empresa</span>
+            <p>
+              Obrato S.A.S nace del compromiso por ofrecer soluciones integrales con calidad y respaldo. 
+              Nuestro modelo de gestión integra protocolos de seguridad, bienestar laboral y responsabilidad social, garantizando resultados confiables. 
+              Acompañamos todo el ciclo operativo, desde el diagnóstico hasta la ejecución y seguimiento, con comunicación transparente y oportuna.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="servicios">
+      <div class="section-inner">
+        <div class="section-heading animate-on-scroll">
+          <span>Expertos a tu servicio</span>
+          <h2>Portafolio integral para mantener, embellecer y optimizar tus instalaciones.</h2>
+          <p>
+            Cada servicio cuenta con equipos especializados, supervisión permanente y protocolos de calidad que aseguran resultados sobresalientes.
+          </p>
+        </div>
+        <div class="services-grid">
+          <article class="card services-card animate-on-scroll">
+            <img src="assets/toderos.svg" alt="Icono servicio de toderos" loading="lazy" />
+            <h3>Toderos</h3>
+            <p>
+              Multitareas capacitados para atender labores de mantenimiento correctivo menor, reparaciones, pintura, plomería ligera y adecuaciones inmediatas.
+            </p>
+          </article>
+          <article class="card services-card animate-on-scroll">
+            <img src="assets/jardineros.svg" alt="Icono jardineros" loading="lazy" />
+            <h3>Jardineros</h3>
+            <p>
+              Especialistas en manejo de zonas verdes, poda ornamental, fertilización y control fitosanitario respetuoso con el entorno.
+            </p>
+          </article>
+          <article class="card services-card animate-on-scroll">
+            <img src="assets/cuadrillas-jardineria.svg" alt="Icono cuadrillas de jardinería" loading="lazy" />
+            <h3>Cuadrillas de jardinería</h3>
+            <p>
+              Equipos coordinados para grandes áreas, con maquinaria especializada, programación por rutas y reportes en tiempo real.
+            </p>
+          </article>
+          <article class="card services-card animate-on-scroll">
+            <img src="assets/personal-servicios.svg" alt="Icono personal de servicios" loading="lazy" />
+            <h3>Personal de servicios</h3>
+            <p>
+              Auxiliares para aseo institucional, manejo de residuos, apoyo logístico y gestión de insumos con enfoque en bioseguridad.
+            </p>
+          </article>
+          <article class="card services-card animate-on-scroll">
+            <img src="assets/locativas.svg" alt="Icono mantenimiento locativo" loading="lazy" />
+            <h3>Locativas</h3>
+            <p>
+              Mantenimiento preventivo y correctivo de infraestructura: electricidad, redes hidráulicas, carpintería, albañilería y remodelaciones.
+            </p>
+          </article>
+          <article class="card services-card animate-on-scroll">
+            <img src="assets/ornamentacion.svg" alt="Icono ornamentación" loading="lazy" />
+            <h3>Ornamentación</h3>
+            <p>
+              Diseño y montaje de elementos decorativos, jardinería interior, paisajismo efímero y ambientación para eventos corporativos.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="dotacion">
+      <div class="section-inner">
+        <div class="section-heading animate-on-scroll">
+          <span>Imagen corporativa</span>
+          <h2>Dotación que protege y proyecta profesionalismo.</h2>
+          <p>
+            Garantizamos uniformes adecuados a las labores, bajo normas de seguridad y confort para nuestros colaboradores.
+          </p>
+        </div>
+        <div class="dotacion-wrapper">
+          <article class="dotacion-card animate-on-scroll">
+            <h3>Personal masculino</h3>
+            <ul class="list-columns">
+              <li>Camibuso gris institucional con reflectivos de seguridad.</li>
+              <li>Pantalones jean de alta resistencia para labores operativas.</li>
+              <li>Botas en material de seguridad con puntera de acero y suela antideslizante.</li>
+            </ul>
+          </article>
+          <article class="dotacion-card animate-on-scroll">
+            <h3>Personal femenino</h3>
+            <ul class="list-columns">
+              <li>Uniforme antifluido gris con cortes ergonómicos.</li>
+              <li>Elementos de protección personal acorde al servicio asignado.</li>
+              <li>Zapatos antideslizantes que garantizan estabilidad y comodidad.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="contacto">
+      <div class="section-inner">
+        <div class="section-heading animate-on-scroll">
+          <span>Conversemos</span>
+          <h2>Diseñamos soluciones a la medida de tu proyecto.</h2>
+          <p>
+            Agenda una visita técnica o solicita una cotización. Nuestro equipo comercial te acompañará en todo el proceso para garantizar resultados sobresalientes.
+          </p>
+        </div>
+        <div class="grid-2">
+          <article class="card animate-on-scroll">
+            <h3>¿Cómo podemos ayudarte?</h3>
+            <p>Completa el formulario y uno de nuestros especialistas se comunicará en menos de 24 horas.</p>
+            <form class="contact-form" aria-label="Formulario de contacto">
+              <label for="nombre">Nombre</label>
+              <input id="nombre" name="nombre" type="text" placeholder="Nombre completo" required />
+
+              <label for="correo">Correo electrónico</label>
+              <input id="correo" name="correo" type="email" placeholder="empresa@correo.com" required />
+
+              <label for="servicio">Servicio de interés</label>
+              <select id="servicio" name="servicio">
+                <option value="toderos">Toderos</option>
+                <option value="jardineria">Jardinería</option>
+                <option value="cuadrillas">Cuadrillas de jardinería</option>
+                <option value="personal">Personal de servicios</option>
+                <option value="locativas">Locativas</option>
+                <option value="ornamentacion">Ornamentación</option>
+              </select>
+
+              <label for="mensaje">Mensaje</label>
+              <textarea id="mensaje" name="mensaje" rows="4" placeholder="Cuéntanos sobre tu necesidad"></textarea>
+
+              <button type="submit" class="btn btn-primary">Enviar mensaje</button>
+            </form>
+          </article>
+          <article class="card animate-on-scroll">
+            <h3>Información de contacto</h3>
+            <ul class="timeline">
+              <li>
+                <strong>Atención comercial</strong><br />
+                Lunes a viernes, 8:00 a.m. - 5:00 p.m.<br />
+                <a href="tel:+573001112233" style="color:var(--primary); font-weight:700; text-decoration:none;">+57 300 111 2233</a>
+              </li>
+              <li>
+                <strong>Correo corporativo</strong><br />
+                <a href="mailto:contacto@obratosas.com" style="color:var(--primary); font-weight:700; text-decoration:none;">contacto@obratosas.com</a>
+              </li>
+              <li>
+                <strong>Ubicación</strong><br />
+                Calle 123 #45-67, Bogotá, Colombia.<br />
+                Atención nacional con cobertura urbana y rural.
+              </li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-inner">
+      <div>
+        <img src="assets/logo.svg" alt="Logotipo Obrato" style="width:120px; margin-bottom:1rem;" />
+        <p>
+          Obrato S.A.S ofrece servicios integrales con calidad y respaldo, potenciando el valor de tus espacios con talento humano experto.
+        </p>
+      </div>
+      <div>
+        <h4 style="margin-bottom:0.85rem;">Servicios</h4>
+        <ul style="list-style:none; padding:0; display:grid; gap:0.5rem;">
+          <li>Toderos</li>
+          <li>Jardineros</li>
+          <li>Cuadrillas de jardinería</li>
+          <li>Personal de servicios</li>
+          <li>Locativas</li>
+          <li>Ornamentación</li>
+        </ul>
+      </div>
+      <div>
+        <h4 style="margin-bottom:0.85rem;">Contacto</h4>
+        <p>Teléfono: +57 300 111 2233</p>
+        <p>Correo: contacto@obratosas.com</p>
+        <p>Bogotá, Colombia</p>
+      </div>
+    </div>
+    <small>© <span id="year"></span> Obrato S.A.S. Todos los derechos reservados.</small>
+  </footer>
+
+  <script>
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, {
+      threshold: 0.2
+    });
+
+    document.querySelectorAll('.animate-on-scroll').forEach((el) => observer.observe(el));
+
+    const yearSpan = document.getElementById('year');
+    if (yearSpan) {
+      yearSpan.textContent = new Date().getFullYear();
+    }
+
+    const navLinks = document.querySelectorAll('nav a');
+    const sections = Array.from(navLinks).map((link) => document.querySelector(link.getAttribute('href'))).filter(Boolean);
+
+    const navObserver = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        const id = entry.target.getAttribute('id');
+        const link = document.querySelector(`nav a[href="#${id}"]`);
+        if (link) {
+          if (entry.isIntersecting) {
+            navLinks.forEach((navLink) => navLink.classList.remove('active'));
+            link.classList.add('active');
+          }
+        }
+      });
+    }, {
+      threshold: 0.4
+    });
+
+    sections.forEach((section) => navObserver.observe(section));
+
+    const form = document.querySelector('.contact-form');
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const formData = new FormData(form);
+      const name = formData.get('nombre');
+      const service = formData.get('servicio');
+      const message = `Hola ${name || 'equipo'}, hemos recibido tu solicitud sobre ${service}. Muy pronto nos pondremos en contacto.`;
+      alert(message);
+      form.reset();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add responsive single-page portfolio for Obrato S.A.S with dynamic hero, company, services, dotación, and contact sections
- include animated navigation highlighting, scroll-triggered reveals, and interactive contact form confirmation
- create custom SVG illustrations for logo and each service offering

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5783e47848328a4ce50a917b2f659